### PR TITLE
make potentiometer spelling consistent

### DIFF
--- a/tkgpio/tkgpio.py
+++ b/tkgpio/tkgpio.py
@@ -60,7 +60,7 @@ class TkCircuit(metaclass=SingletonMeta):
         
         if setup["adc"] != None:
             spi = TkSPI(setup["adc"]["mcp_chip"])
-            for parameters in setup["adc"]["potenciometers"]:
+            for parameters in setup["adc"]["potentiometers"]:
                 parameters["tk_spi"] = spi
                 self.add_device(TkPotentiometer, parameters)
                 


### PR DESCRIPTION
In config uses "potenciometer" but in tkgpio.py uses "potentiometer". Would be nice to have consistency there